### PR TITLE
Update 2000-01-06-users.md

### DIFF
--- a/_posts/documentation/explore/2000-01-06-users.md
+++ b/_posts/documentation/explore/2000-01-06-users.md
@@ -9,14 +9,14 @@ permalink: users.html
 
 The following open-source projects are using PhantomJS as part of the testing workflow:
 
-* Bootstrap
-* CodeMirror
-* Ember.js
-* Grunt
-* Modernizr
-* YUI3
-* Zepto
-* Durandaljs
+* [Bootstrap](https://github.com/twbs/bootstrap)
+* [CodeMirror](https://github.com/codemirror/CodeMirror)
+* [Ember.js](https://github.com/emberjs)
+* [Grunt](https://github.com/gruntjs/grunt)
+* [Modernizr](https://github.com/Modernizr/Modernizr)
+* [YUI3](https://github.com/yui/yui3)
+* [Zepto](https://github.com/madrobby/zepto)
+* [Durandal](https://github.com/BlueSpire/Durandal)
 
 ## Organizations
 


### PR DESCRIPTION
Added GitHub links to open-source projects and changed Durandaljs to Durandal (seems to be the preferred name based on how they refer to themselves in readme).